### PR TITLE
Fix/gdext v0.1.1

### DIFF
--- a/dijkstra-map-gd/Cargo.toml
+++ b/dijkstra-map-gd/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 fnv = "1.0.7"
-godot = { git = "https://github.com/godot-rust/gdext.git", branch = "master", features = ["custom-godot"] }
+godot = { git = "https://github.com/godot-rust/gdext.git", tag = "v0.1.1", features = ["custom-godot"] }
 dijkstra_map = { path = "../dijkstra-map" }
 
 [build-dependencies]

--- a/dijkstra-map-gd/src/lib.rs
+++ b/dijkstra-map-gd/src/lib.rs
@@ -659,6 +659,7 @@ impl DijkstraMap {
                 VariantType::StringName => "StringName",
                 VariantType::Callable => "Callable",
                 VariantType::Signal => "Signal",
+                VariantType => "VariantType",
             }
         }
 


### PR DESCRIPTION
What have been done:
1. Fixing a compilation error
```rust
error[E0004]: non-exhaustive patterns: `godot::prelude::VariantType { ord: i32::MIN..=-1_i32 }` and `godot::prelude::VariantType { ord: 38_i32..=i32::MAX }` not covered
   --> dijkstra-map-gd/src/lib.rs:623:19
    |
623 |             match t {
    |                   ^ patterns `godot::prelude::VariantType { ord: i32::MIN..=-1_i32 }` and `godot::prelude::VariantType { ord: 38_i32..=i32::MAX }` not covered
    |
 ```
 
 2.  Specified a specific version of gdext. [They released on crates.io](https://godot-rust.github.io/dev/june-2024-update/) and now we can use tags instead of master branch.