### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -34,7 +34,7 @@ jobs:
           args: --release --verbose -p dijkstra_map_gd
       - name: Strip library file
         run: strip target/release/libdijkstra_map_gd.so
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libdijkstra_map_gd.so
           path: target/release/libdijkstra_map_gd.so
@@ -62,7 +62,7 @@ jobs:
         with:
           command: build
           args: --release --verbose -p dijkstra_map_gd --target x86_64-pc-windows-gnu
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dijkstra_map_gd.dll
           path: target/x86_64-pc-windows-gnu/release/dijkstra_map_gd.dll
@@ -86,7 +86,7 @@ jobs:
         with:
           command: build
           args: --release -p dijkstra_map_gd
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libdijkstra_map_gd.dylib
           path: target/release/libdijkstra_map_gd.dylib


### PR DESCRIPTION
v3 of the `actions/upload-artifact` tool, which is used in the "Build shared libraries" workflow, is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

The PR updates it to v4, as this was preventing the workflow from running.

This means that GH Actions can now be used to build the libraries—
Notably, macOS binaries can be built through GitHub's infrastructure, eliminating the need for a local Mac to build release artifacts.